### PR TITLE
Fix autocomplete settings

### DIFF
--- a/Source/Tincta/TextEditor/TCTextView.m
+++ b/Source/Tincta/TextEditor/TCTextView.m
@@ -70,24 +70,34 @@
     
     if ((shallAutocompleteBrackets || shallAutocompleteQuotations)
         && [insertString isKindOfClass:[NSString class]]) {
-        // auto complete brackets
-        if ([insertString isEqualToString:@"("]) {
-            [super insertText:@")"];
-        } else if ([insertString isEqualToString:@"["]) {
-            [super insertText:@"]"];
-        } else if ([insertString isEqualToString:@"{"]) {
-            [super insertText:@"}"];
-        // auto complete quotations
-        } else if ([insertString isEqualToString:@"\""]) {
-            [super insertText:@"\""];
-        } else if ([insertString isEqualToString:@"'"]) {
-            [super insertText:@"'"];
-        // no autocompletion
-        } else {
-            return;
+        BOOL hasInsertedAutoComplete = false;
+        if (shallAutocompleteBrackets) {
+            if ([insertString isEqualToString:@"("]) {
+                [super insertText:@")"];
+                hasInsertedAutoComplete = true;
+            } else if ([insertString isEqualToString:@"["]) {
+                [super insertText:@"]"];
+                hasInsertedAutoComplete = true;
+            } else if ([insertString isEqualToString:@"{"]) {
+                [super insertText:@"}"];
+                hasInsertedAutoComplete = true;
+            }
+        }
+        if (shallAutocompleteQuotations) {
+            if ([insertString isEqualToString:@"\""]) {
+                [super insertText:@"\""];
+                hasInsertedAutoComplete = true;
+            } else if ([insertString isEqualToString:@"'"]) {
+                [super insertText:@"'"];
+                hasInsertedAutoComplete = true;
+            }
         }
         
-        // insertion point between the braces or quotations marks
+        if (!hasInsertedAutoComplete) {
+            return; //nothing more to do here
+        }
+        
+        // put insertion point between the braces or quotations marks
         NSArray* selRanges = @[[NSValue valueWithRange:NSMakeRange([self selectedRange].location - 1, 0)]];
         [self setSelectedRanges:selRanges];
     }


### PR DESCRIPTION
Fixes a bug that autocomplete setting for brackets and quotes would be ORed making the settings not work properly.
In fact, this bug must have been there ever since the very first version of Tincta 10 years ago. 

closes #45 